### PR TITLE
Child VSpace

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ is probably the most common way that libGDB might be used, as it is the most fle
 This library depends on seL4 and microkit changes that have not been upstreamed. As such, a custom version of the
 microkit will have to be built using the following sources.
 
-microkit: [https://github.com/alwin-joshy/microkit/tree/gdb_2025](https://github.com/alwin-joshy/microkit/tree/gdb_2025)
+microkit: [https://github.com/au-ts/microkit/tree/child_vspace](https://github.com/au-ts/microkit/tree/child_vspace)
 
-seL4: [https://github.com/alwin-joshy/seL4/tree/gdb_2025](https://github.com/alwin-joshy/seL4/tree/gdb_2025)
+seL4: [https://github.com/au-ts/seL4/tree/libgdb](https://github.com/au-ts/seL4/tree/libgdb)
 
 The examples depend on the `aarch64-none-elf` toolchain for compilation, and libGDB has only been tested with `aarch64-none-elf-gdb`,
 though any GDB that has architecture support for aarch64 should suffice.

--- a/examples/microkit_sddf_net/Makefile
+++ b/examples/microkit_sddf_net/Makefile
@@ -56,6 +56,7 @@ export OBJCOPY := $(TOOLCHAIN)-objcopy
 export MICROKIT_TOOL ?= $(MICROKIT_SDK)/bin/microkit
 export SDDF=$(abspath ../../sddf)
 export LIBGDB_DIR=$(abspath ../../)
+export LIBVSPACE_DIR=$(abspath ../../libvspace)
 export DEBUGGER_INCLUDE:=$(abspath .)/apps/debugger/include
 
 IMAGE_FILE := $(BUILD_DIR)/loader.img

--- a/examples/microkit_sddf_net/apps/debugger/debugger.c
+++ b/examples/microkit_sddf_net/apps/debugger/debugger.c
@@ -5,7 +5,6 @@
 
 #include <microkit.h>
 
-
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
@@ -82,6 +81,71 @@ bool tcp_initialized = false;
 static bool debugger_initialized = false;
 
 #define NUM_DEBUGEES 2
+
+// Define table data regions for our child
+microkit_uint64_t table_metadata[64];
+microkit_uint64_t table_data[0x800 * (NUM_DEBUGEES + 100)];
+
+microkit_uint64_t walk_table(microkit_uint64_t *start, uintptr_t addr, int lvl)
+{
+    // Get the 9 bit index for this level.
+    uintptr_t index = 0;
+    if (lvl == 1) {
+        // Index into the PUD
+        index = (addr & ((uintptr_t)0x1ff << 30)) >> 30;
+    } else if (lvl == 2) {
+        // Index into the PD
+        index = (addr & ((uintptr_t)0x1ff << 21)) >> 21;
+    } else if (lvl == 3) {
+        // Index into the PT
+        index = (addr & ((uintptr_t)0x1ff << 12)) >> 12;
+    }
+    if (lvl == 3) {
+       return start[index];
+    } else {
+        walk_table(&table_data[start[index]/8], addr, lvl + 1);
+    }
+}
+
+seL4_Word get_page(uint8_t child_id, uintptr_t addr) {
+    microkit_uint64_t page = walk_table(&table_data[table_metadata[0]/8], addr, 0);
+    return page;
+}
+
+uint32_t read_word(uint16_t client, uintptr_t addr, seL4_Word *val) {
+    seL4_Word page = get_page(0, addr);
+    if (page == 0 || page == 0xffffffffffffffff) {
+        return 1;
+    }
+
+    int err = seL4_ARM_Page_Map(page, VSPACE_CAP, 0x900000, seL4_AllRights, seL4_ARM_Default_VMAttributes);
+
+    if (err) {
+        microkit_dbg_puts("We got an error when mapping page in read_word()");
+    }
+
+    uint64_t *ptr_to_page = (uint64_t *) (0x900000 + (addr & 0xfff));
+    *val = *ptr_to_page;
+    return 0;
+}
+
+uint32_t write_word(uint16_t client, uintptr_t addr, seL4_Word val) {
+    microkit_dbg_puts("Writing word\n");
+    seL4_Word page = get_page(0, addr);
+    if (page == 0 || page == 0xffffffffffffffff) {
+        return 1;
+    }
+    int err = seL4_ARM_Page_Map(page, VSPACE_CAP, 0x900000, seL4_AllRights, seL4_ARM_Default_VMAttributes);
+
+    if (err) {
+        microkit_dbg_puts("We got an error when mapping page in write_word()");
+    }
+
+    uint64_t *ptr_to_page = (uint64_t *) (0x900000 + (addr & 0xfff));
+    *ptr_to_page = val;
+    return 0;
+}
+
 
 void _putchar(char character) {
     microkit_dbg_putc(character);

--- a/examples/microkit_sddf_net/apps/debugger/debugger.c
+++ b/examples/microkit_sddf_net/apps/debugger/debugger.c
@@ -8,6 +8,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <string.h>
 #include <microkit.h>
 #include <sddf/util/util.h>
 #include <sddf/util/string.h>
@@ -24,6 +25,7 @@
 #include "lwip/pbuf.h"
 #include <libco.h>
 #include <gdb.h>
+#include <util.h>
 
 #include "tcp.h"
 #include "char_queue.h"
@@ -38,6 +40,8 @@ __attribute__((__section__(".net_client_config"))) net_client_config_t net_confi
 
 __attribute__((__section__(".lib_sddf_lwip_config"))) lib_sddf_lwip_config_t lib_sddf_lwip_config;
 
+
+int setup_tcp_socket(void);
 
 typedef enum event_state {
     eventState_none = 0,

--- a/examples/microkit_sddf_net/meta.py
+++ b/examples/microkit_sddf_net/meta.py
@@ -108,7 +108,7 @@ def generate(sdf_file: str, output_dir: str, dtb: DeviceTree):
     net_virt_rx = ProtectionDomain("net_virt_rx", "network_virt_rx.elf", priority=99)
     net_system = Sddf.Net(sdf, ethernet_node, ethernet_driver, net_virt_tx, net_virt_rx)
 
-    debugger = ProtectionDomain("debugger", "debugger.elf", priority=97, budget=20000, stack_size=0x20000)
+    debugger = ProtectionDomain("debugger", "debugger.elf", priority=97, budget=20000, stack_size=0x20000, child_pts=True)
     debugger_net_copier = ProtectionDomain(
         "debugger_net_copier", "network_copy.elf", priority=98, budget=20000
     )

--- a/examples/microkit_sddf_net/meta.py
+++ b/examples/microkit_sddf_net/meta.py
@@ -119,13 +119,23 @@ def generate(sdf_file: str, output_dir: str, dtb: DeviceTree):
 
     debugger_lib_sddf_lwip = Sddf.Lwip(sdf, net_system, debugger)
 
-    mr = MemoryRegion("mr1", 0x1000)
-    sdf.add_mr(mr)
-    map = Map(mr, 0x900000, "rw")
-    debugger.add_map(map)
+    small_mapping_region = MemoryRegion("small_region", 0x1000)
+    sdf.add_mr(small_mapping_region)
+    small_map = Map(small_mapping_region, 0x900000, "rw", setvar_vaddr="small_mapping_mr")
+    debugger.add_map(small_map)
+
+    large_mapping_region = MemoryRegion("large_region", 0x200000, page_size=MemoryRegion.PageSize.LargePage)
+    sdf.add_mr(large_mapping_region)
+    large_map = Map(large_mapping_region, 0xa00000, "rw", setvar_vaddr="large_mapping_mr")
+    debugger.add_map(large_map)
 
     ping = ProtectionDomain("ping", "ping.elf", priority=1)
     pong = ProtectionDomain("pong", "pong.elf", priority=1)
+
+    ping_large_page = MemoryRegion("ping_large_page", 0x200000, page_size=MemoryRegion.PageSize.LargePage)
+    sdf.add_mr(ping_large_page)
+    ping_large_page_map = Map(ping_large_page, 0x800000, "rw", setvar_vaddr="mr")
+    ping.add_map(ping_large_page_map)
 
     debug_pds = [
         ping,

--- a/examples/microkit_sddf_net/meta.py
+++ b/examples/microkit_sddf_net/meta.py
@@ -119,6 +119,11 @@ def generate(sdf_file: str, output_dir: str, dtb: DeviceTree):
 
     debugger_lib_sddf_lwip = Sddf.Lwip(sdf, net_system, debugger)
 
+    mr = MemoryRegion("mr1", 0x1000)
+    sdf.add_mr(mr)
+    map = Map(mr, 0x600000, "rw")
+    debugger.add_map(map)
+
     ping = ProtectionDomain("ping", "ping.elf", priority=1)
     pong = ProtectionDomain("pong", "pong.elf", priority=1)
 

--- a/examples/microkit_sddf_net/meta.py
+++ b/examples/microkit_sddf_net/meta.py
@@ -121,7 +121,7 @@ def generate(sdf_file: str, output_dir: str, dtb: DeviceTree):
 
     mr = MemoryRegion("mr1", 0x1000)
     sdf.add_mr(mr)
-    map = Map(mr, 0x600000, "rw")
+    map = Map(mr, 0x900000, "rw")
     debugger.add_map(map)
 
     ping = ProtectionDomain("ping", "ping.elf", priority=1)

--- a/examples/microkit_sddf_net/sddf_net_example.mk
+++ b/examples/microkit_sddf_net/sddf_net_example.mk
@@ -87,12 +87,12 @@ DEPS := $(DEBUGGER_OBJS:.o=.d)
 all: loader.img
 
 ${DEBUGGER_OBJS}: ${CHECK_FLAGS_BOARD_MD5}
-debugger.elf: $(DEBUGGER_OBJS) libsddf_util.a lib_sddf_lwip.a libgdb.a libco.a
-	$(LD) $(LDFLAGS) $(DEBUGGER_OBJS) libsddf_util.a lib_sddf_lwip.a libvsapce.a libgdb.a libco.a $(LIBS) -o $@
+debugger.elf: $(DEBUGGER_OBJS) libsddf_util.a lib_sddf_lwip.a libgdb.a libco.a libvspace.a
+	$(LD) $(LDFLAGS) $(DEBUGGER_OBJS) libsddf_util.a lib_sddf_lwip.a libvspace.a libgdb.a libco.a $(LIBS) -o $@
 
 # Need to build libsddf_util_debug.a because it's included in LIBS
 # for the unimplemented libc dependencies
-${IMAGES}: libsddf_util_debug.a
+${IMAGES}: libsddf_util_debug.a libvspace.a
 
 $(DTB): $(DTS)
 	dtc -q -I dts -O dtb $(DTS) > $(DTB)

--- a/examples/microkit_sddf_net/sddf_net_example.mk
+++ b/examples/microkit_sddf_net/sddf_net_example.mk
@@ -57,7 +57,7 @@ CFLAGS := -mcpu=$(CPU) \
 	  -MP
 
 LDFLAGS := -L$(BOARD_DIR)/lib -L${LIBC}
-LIBS := --start-group -lmicrokit -Tmicrokit.ld -lc libsddf_util_debug.a --end-group
+LIBS := --start-group -lmicrokit -Tmicrokit.ld -lc libsddf_util_debug.a libvspace.a --end-group
 
 CHECK_FLAGS_BOARD_MD5 := .board_cflags-$(shell echo -- ${CFLAGS} ${BOARD} ${MICROKIT_CONFIG} | shasum | sed 's/ *-//')
 
@@ -88,7 +88,7 @@ all: loader.img
 
 ${DEBUGGER_OBJS}: ${CHECK_FLAGS_BOARD_MD5}
 debugger.elf: $(DEBUGGER_OBJS) libsddf_util.a lib_sddf_lwip.a libgdb.a libco.a
-	$(LD) $(LDFLAGS) $(DEBUGGER_OBJS) libsddf_util.a lib_sddf_lwip.a libgdb.a libco.a $(LIBS) -o $@
+	$(LD) $(LDFLAGS) $(DEBUGGER_OBJS) libsddf_util.a lib_sddf_lwip.a libvsapce.a libgdb.a libco.a $(LIBS) -o $@
 
 # Need to build libsddf_util_debug.a because it's included in LIBS
 # for the unimplemented libc dependencies
@@ -127,6 +127,7 @@ include ${SERIAL_DRIVER}/serial_driver.mk
 include ${SERIAL_COMPONENTS}/serial_components.mk
 include $(LIBGDB_DIR)/libgdb.mk
 include ${SDDF}/libco/libco.mk
+include $(LIBVSPACE_DIR)/libvspace.mk
 
 qemu: $(IMAGE_FILE)
 	$(QEMU) -machine virt,virtualization=on \

--- a/examples/microkit_sddf_net/sddf_net_example.mk
+++ b/examples/microkit_sddf_net/sddf_net_example.mk
@@ -53,11 +53,12 @@ CFLAGS := -mcpu=$(CPU) \
 	  -I$(SDDF)/libco \
 	  -I$(LIBGDB_DIR)/include \
 	  -I$(LIBGDB_DIR)/arch_include \
+	  -I$(LIBVSPACE_DIR) \
 	  -MD \
 	  -MP
 
 LDFLAGS := -L$(BOARD_DIR)/lib -L${LIBC}
-LIBS := --start-group -lmicrokit -Tmicrokit.ld -lc libsddf_util_debug.a libvspace.a --end-group
+LIBS := --start-group -lmicrokit -Tmicrokit.ld -lc libsddf_util_debug.a --end-group
 
 CHECK_FLAGS_BOARD_MD5 := .board_cflags-$(shell echo -- ${CFLAGS} ${BOARD} ${MICROKIT_CONFIG} | shasum | sed 's/ *-//')
 
@@ -88,7 +89,7 @@ all: loader.img
 
 ${DEBUGGER_OBJS}: ${CHECK_FLAGS_BOARD_MD5}
 debugger.elf: $(DEBUGGER_OBJS) libsddf_util.a lib_sddf_lwip.a libgdb.a libco.a libvspace.a
-	$(LD) $(LDFLAGS) $(DEBUGGER_OBJS) libsddf_util.a lib_sddf_lwip.a libvspace.a libgdb.a libco.a $(LIBS) -o $@
+	$(LD) $(LDFLAGS) $(DEBUGGER_OBJS) libsddf_util.a lib_sddf_lwip.a libgdb.a libvspace.a libco.a $(LIBS) -o $@
 
 # Need to build libsddf_util_debug.a because it's included in LIBS
 # for the unimplemented libc dependencies

--- a/examples/microkit_sddf_serial/Makefile
+++ b/examples/microkit_sddf_serial/Makefile
@@ -46,6 +46,7 @@ export MICROKIT_TOOL ?= $(MICROKIT_SDK)/bin/microkit
 export SDDF=$(abspath ../../sddf)
 export DEBUGGER_INCLUDE:=$(abspath .)/include
 export LIBGDB_DIR := $(abspath ../../)
+export LIBVSPACE_DIR=$(abspath ../../libvspace)
 
 IMAGE_FILE := $(BUILD_DIR)/loader.img
 REPORT_FILE := $(BUILD_DIR)/report.txt

--- a/examples/microkit_sddf_serial/apps/debugger/debugger.c
+++ b/examples/microkit_sddf_serial/apps/debugger/debugger.c
@@ -25,6 +25,7 @@ typedef enum event_state {
 
 cothread_t t_event, t_main, t_fault;
 
+// TODO - DO NOT DEFINE THIS IN MULTIPLE PLACES
 #define NUM_DEBUGEES 2
 
 #define STACK_SIZE 4096
@@ -49,71 +50,6 @@ serial_queue_handle_t tx_queue_handle;
 /* The current event state and phase */
 event_state_t state = eventState_none;
 static bool detached = false;
-
-
-// Define table data regions for our child
-microkit_uint64_t table_metadata[64];
-microkit_uint64_t table_data[0x800 * (NUM_DEBUGEES + 100)];
-
-microkit_uint64_t walk_table(microkit_uint64_t *start, uintptr_t addr, int lvl)
-{
-    // Get the 9 bit index for this level.
-    uintptr_t index = 0;
-    if (lvl == 1) {
-        // Index into the PUD
-        index = (addr & ((uintptr_t)0x1ff << 30)) >> 30;
-    } else if (lvl == 2) {
-        // Index into the PD
-        index = (addr & ((uintptr_t)0x1ff << 21)) >> 21;
-    } else if (lvl == 3) {
-        // Index into the PT
-        index = (addr & ((uintptr_t)0x1ff << 12)) >> 12;
-    }
-    if (lvl == 3) {
-       return start[index];
-    } else {
-        walk_table(&table_data[start[index]/8], addr, lvl + 1);
-    }
-}
-
-seL4_Word get_page(uint8_t child_id, uintptr_t addr) {
-    microkit_uint64_t page = walk_table(&table_data[table_metadata[0]/8], addr, 0);
-    return page;
-}
-
-uint32_t read_word(uint16_t client, uintptr_t addr, seL4_Word *val) {
-    seL4_Word page = get_page(0, addr);
-    if (page == 0 || page == 0xffffffffffffffff) {
-        return 1;
-    }
-
-    int err = seL4_ARM_Page_Map(page, VSPACE_CAP, 0x600000, seL4_AllRights, seL4_ARM_Default_VMAttributes);
-
-    if (err) {
-        microkit_dbg_puts("We got an error when mapping page in read_word()");
-    }
-
-    uint64_t *ptr_to_page = (uint64_t *) (0x600000 + (addr & 0xfff));
-    *val = *ptr_to_page;
-    return 0;
-}
-
-uint32_t write_word(uint16_t client, uintptr_t addr, seL4_Word val) {
-    microkit_dbg_puts("Writing word\n");
-    seL4_Word page = get_page(0, addr);
-    if (page == 0 || page == 0xffffffffffffffff) {
-        return 1;
-    }
-    int err = seL4_ARM_Page_Map(page, VSPACE_CAP, 0x600000, seL4_AllRights, seL4_ARM_Default_VMAttributes);
-
-    if (err) {
-        microkit_dbg_puts("We got an error when mapping page in write_word()");
-    }
-
-    uint64_t *ptr_to_page = (uint64_t *) (0x600000 + (addr & 0xfff));
-    *ptr_to_page = val;
-    return 0;
-}
 
 void _putchar(char character) {
     microkit_dbg_putc(character);

--- a/examples/microkit_sddf_serial/apps/debugger/debugger.c
+++ b/examples/microkit_sddf_serial/apps/debugger/debugger.c
@@ -15,26 +15,6 @@
 #include <sddf/util/printf.h>
 #include <sddf/serial/config.h>
 
-#define CHILD_PDS 2
-
-static char hexchar(unsigned int v)
-{
-    return v < 10 ? '0' + v : ('a' - 10) + v;
-}
-
-void puthex64(uint64_t val)
-{
-    char buffer[16 + 3];
-    buffer[0] = '0';
-    buffer[1] = 'x';
-    buffer[16 + 3 - 1] = 0;
-    for (unsigned i = 16 + 1; i > 1; i--) {
-        buffer[i] = hexchar(val & 0xf);
-        val >>= 4;
-    }
-    microkit_dbg_puts(buffer);
-}
-
 __attribute__((__section__(".serial_client_config"))) serial_client_config_t config;
 
 typedef enum event_state {

--- a/examples/microkit_sddf_serial/apps/debugger/debugger.c
+++ b/examples/microkit_sddf_serial/apps/debugger/debugger.c
@@ -15,6 +15,26 @@
 #include <sddf/util/printf.h>
 #include <sddf/serial/config.h>
 
+#define CHILD_PDS 2
+
+static char hexchar(unsigned int v)
+{
+    return v < 10 ? '0' + v : ('a' - 10) + v;
+}
+
+void puthex64(uint64_t val)
+{
+    char buffer[16 + 3];
+    buffer[0] = '0';
+    buffer[1] = 'x';
+    buffer[16 + 3 - 1] = 0;
+    for (unsigned i = 16 + 1; i > 1; i--) {
+        buffer[i] = hexchar(val & 0xf);
+        val >>= 4;
+    }
+    microkit_dbg_puts(buffer);
+}
+
 __attribute__((__section__(".serial_client_config"))) serial_client_config_t config;
 
 typedef enum event_state {
@@ -50,6 +70,70 @@ serial_queue_handle_t tx_queue_handle;
 event_state_t state = eventState_none;
 static bool detached = false;
 
+
+// Define table data regions for our child
+microkit_uint64_t table_metadata[64];
+microkit_uint64_t table_data[0x800 * (NUM_DEBUGEES + 100)];
+
+microkit_uint64_t walk_table(microkit_uint64_t *start, uintptr_t addr, int lvl)
+{
+    // Get the 9 bit index for this level.
+    uintptr_t index = 0;
+    if (lvl == 1) {
+        // Index into the PUD
+        index = (addr & ((uintptr_t)0x1ff << 30)) >> 30;
+    } else if (lvl == 2) {
+        // Index into the PD
+        index = (addr & ((uintptr_t)0x1ff << 21)) >> 21;
+    } else if (lvl == 3) {
+        // Index into the PT
+        index = (addr & ((uintptr_t)0x1ff << 12)) >> 12;
+    }
+    if (lvl == 3) {
+       return start[index];
+    } else {
+        walk_table(&table_data[start[index]/8], addr, lvl + 1);
+    }
+}
+
+seL4_Word get_page(uint8_t child_id, uintptr_t addr) {
+    microkit_uint64_t page = walk_table(&table_data[table_metadata[0]/8], addr, 0);
+    return page;
+}
+
+uint32_t read_word(uint16_t client, uintptr_t addr, seL4_Word *val) {
+    seL4_Word page = get_page(0, addr);
+    if (page == 0 || page == 0xffffffffffffffff) {
+        return 1;
+    }
+
+    int err = seL4_ARM_Page_Map(page, VSPACE_CAP, 0x600000, seL4_AllRights, seL4_ARM_Default_VMAttributes);
+
+    if (err) {
+        microkit_dbg_puts("We got an error when mapping page in read_word()");
+    }
+
+    uint64_t *ptr_to_page = (uint64_t *) (0x600000 + (addr & 0xfff));
+    *val = *ptr_to_page;
+    return 0;
+}
+
+uint32_t write_word(uint16_t client, uintptr_t addr, seL4_Word val) {
+    microkit_dbg_puts("Writing word\n");
+    seL4_Word page = get_page(0, addr);
+    if (page == 0 || page == 0xffffffffffffffff) {
+        return 1;
+    }
+    int err = seL4_ARM_Page_Map(page, VSPACE_CAP, 0x600000, seL4_AllRights, seL4_ARM_Default_VMAttributes);
+
+    if (err) {
+        microkit_dbg_puts("We got an error when mapping page in write_word()");
+    }
+
+    uint64_t *ptr_to_page = (uint64_t *) (0x600000 + (addr & 0xfff));
+    *ptr_to_page = val;
+    return 0;
+}
 
 void _putchar(char character) {
     microkit_dbg_putc(character);

--- a/examples/microkit_sddf_serial/meta.py
+++ b/examples/microkit_sddf_serial/meta.py
@@ -49,7 +49,7 @@ def generate(sdf_file: str, output_dir: str, dtb: DeviceTree):
 
     mr = MemoryRegion("mr1", 0x1000)
     sdf.add_mr(mr)
-    map = Map(mr, 0x600000, "rw")
+    map = Map(mr, 0x900000, "rw")
     debugger.add_map(map)
 
     ping = ProtectionDomain("ping", "ping.elf", priority=96)

--- a/examples/microkit_sddf_serial/meta.py
+++ b/examples/microkit_sddf_serial/meta.py
@@ -10,6 +10,8 @@ assert version('sdfgen').split(".")[1] == "24", "Unexpected sdfgen version"
 
 ProtectionDomain = SystemDescription.ProtectionDomain
 Channel = SystemDescription.Channel
+MemoryRegion = SystemDescription.MemoryRegion
+Map = SystemDescription.Map
 
 @dataclass
 class Board:
@@ -44,6 +46,11 @@ def generate(sdf_file: str, output_dir: str, dtb: DeviceTree):
     serial_virt_tx = ProtectionDomain("serial_virt_tx", "serial_virt_tx.elf", priority=99)
     serial_virt_rx = ProtectionDomain("serial_virt_rx", "serial_virt_rx.elf", priority=99)
     debugger = ProtectionDomain("debugger", "debugger.elf", priority=97)
+
+    mr = MemoryRegion("mr1", 0x1000)
+    sdf.add_mr(mr)
+    map = Map(mr, 0x600000, "rw")
+    debugger.add_map(map)
 
     ping = ProtectionDomain("ping", "ping.elf", priority=96)
     pong = ProtectionDomain("pong", "pong.elf", priority=96)

--- a/examples/microkit_sddf_serial/sddf_serial_example.mk
+++ b/examples/microkit_sddf_serial/sddf_serial_example.mk
@@ -47,7 +47,7 @@ CFLAGS := -mcpu=$(CPU) \
 	  -MP
 
 LDFLAGS := -L$(BOARD_DIR)/lib -L${LIBC}
-LIBS := --start-group -lmicrokit -Tmicrokit.ld -lc libsddf_util_debug.a --end-group
+LIBS := --start-group -lmicrokit -Tmicrokit.ld -lc libsddf_util_debug.a libvspace.a --end-group
 
 CHECK_FLAGS_BOARD_MD5 := .board_cflags-$(shell echo -- ${CFLAGS} ${BOARD} ${MICROKIT_CONFIG} | shasum | sed 's/ *-//')
 
@@ -76,11 +76,11 @@ all: loader.img
 
 ${DEBUGGER_OBJS}: ${CHECK_FLAGS_BOARD_MD5}
 debugger.elf: $(DEBUGGER_OBJS) libsddf_util.a libgdb.a libco.a
-	$(LD) $(LDFLAGS) $(DEBUGGER_OBJS) libsddf_util.a libgdb.a libco.a $(LIBS) -o $@
+	$(LD) $(LDFLAGS) $(DEBUGGER_OBJS) libsddf_util.a libvspace.a libgdb.a libco.a $(LIBS) -o $@
 
 # Need to build libsddf_util_debug.a because it's included in LIBS
 # for the unimplemented libc dependencies
-${IMAGES}: libsddf_util_debug.a
+${IMAGES}: libsddf_util_debug.a libvspace.a
 
 $(DTB): $(DTS)
 	dtc -q -I dts -O dtb $(DTS) > $(DTB)
@@ -101,6 +101,7 @@ include ${SERIAL_DRIVER}/serial_driver.mk
 include ${SERIAL_COMPONENTS}/serial_components.mk
 include $(LIBGDB_DIR)/libgdb.mk
 include ${SDDF}/libco/libco.mk
+include $(LIBVSPACE_DIR)/libvspace.mk
 
 qemu: $(IMAGE_FILE)
 	$(QEMU) -machine virt,virtualization=on \

--- a/include/gdb.h
+++ b/include/gdb.h
@@ -132,5 +132,5 @@ DebuggerError gdb_handle_fault(uint64_t inferior_id, uint64_t thread_id, seL4_Wo
 bool gdb_handle_packet(char *input, char *output, bool *detached);
 
 /* VSpace functions to be implemented by the user. */
-extern uint32_t read_word(uint16_t client, uintptr_t addr, seL4_Word *val);
-extern uint32_t write_word(uint16_t client, uintptr_t addr, seL4_Word val);
+extern uint32_t read_word(uint16_t client, uintptr_t addr, seL4_Word *val, seL4_Word map_addr);
+extern uint32_t write_word(uint16_t client, uintptr_t addr, seL4_Word val, seL4_Word map_addr);

--- a/include/gdb.h
+++ b/include/gdb.h
@@ -40,6 +40,7 @@ typedef struct hw_breakpoint {
 typedef struct sw_breakpoint {
     uint64_t addr;
     uint64_t orig_word;
+    bool set;
 } sw_break_t;
 
 struct inferior;

--- a/include/gdb.h
+++ b/include/gdb.h
@@ -132,5 +132,5 @@ DebuggerError gdb_handle_fault(uint64_t inferior_id, uint64_t thread_id, seL4_Wo
 bool gdb_handle_packet(char *input, char *output, bool *detached);
 
 /* VSpace functions to be implemented by the user. */
-extern uint32_t read_word(uint16_t client, uintptr_t addr, seL4_Word *val, seL4_Word map_addr);
-extern uint32_t write_word(uint16_t client, uintptr_t addr, seL4_Word val, seL4_Word map_addr);
+extern uint32_t gdb_read_word(uint16_t client, uintptr_t addr, seL4_Word *val);
+extern uint32_t gdb_write_word(uint16_t client, uintptr_t addr, seL4_Word val);

--- a/include/gdb.h
+++ b/include/gdb.h
@@ -131,3 +131,6 @@ DebuggerError gdb_handle_fault(uint64_t inferior_id, uint64_t thread_id, seL4_Wo
                                seL4_Word *reply_mr, char *output, bool* have_reply);
 bool gdb_handle_packet(char *input, char *output, bool *detached);
 
+/* VSpace functions to be implemented by the user. */
+extern uint32_t read_word(uint16_t client, uintptr_t addr, seL4_Word *val);
+extern uint32_t write_word(uint16_t client, uintptr_t addr, seL4_Word val);

--- a/include/gdb.h
+++ b/include/gdb.h
@@ -114,6 +114,7 @@ bool disable_single_step(gdb_thread_t *thread);
 /* Convert registers to a hex string */
 char *regs2hex(seL4_UserContext *regs, char *buf);
 
+char *regs2print(seL4_UserContext *regs, char *buf);
 /* Convert registers to a hex string */
 char *hex2regs(seL4_UserContext *regs, char *buf);
 
@@ -132,5 +133,7 @@ DebuggerError gdb_handle_fault(uint64_t inferior_id, uint64_t thread_id, seL4_Wo
 bool gdb_handle_packet(char *input, char *output, bool *detached);
 
 /* VSpace functions to be implemented by the user. */
-extern uint32_t gdb_read_word(uint16_t client, uintptr_t addr, seL4_Word *val);
+extern uint32_t gdb_read_word(uint16_t client, uintptr_t addr, char *val);
+extern uint32_t gdb_read_bytes(uint16_t client, uintptr_t start_addr, char *buff, uint64_t nbytes);
 extern uint32_t gdb_write_word(uint16_t client, uintptr_t addr, seL4_Word val);
+extern uint32_t gdb_write_bytes(uint16_t client, uintptr_t start_addr, char *buff, uint64_t nbytes);

--- a/libvspace/libvspace.mk
+++ b/libvspace/libvspace.mk
@@ -1,0 +1,24 @@
+OBJS_LIBVSPACE := vspace.o
+
+ALL_OBJS_LIBVSPACE := $(addprefix libvspace/, ${OBJS_LIBVSPACE})
+
+${ALL_OBJS_LIBUTIL}: |libvspace
+
+libvspace.a: ${ALL_OBJS_LIBVSPACE}
+	${AR} crv $@ $^
+	${RANLIB} $@
+
+libvspace/%.o: ${LIBVSPACE_DIR}/%.c
+	${CC} ${CFLAGS} -c -o $@ $<
+
+libvspace:
+	mkdir -p $@
+
+clean::
+	${RM} -f ${ALL_OBJS_LIBVSPACE} ${ALL_OBJS_LIBVSPACE:.o=.d}
+
+clobber:: clean
+	${RM} -f libvspace.a
+	rmdir libvspace
+
+-include ${ALL_OBJS_LIBVSPACE:.o=.d}

--- a/libvspace/vspace.c
+++ b/libvspace/vspace.c
@@ -1,0 +1,68 @@
+#include <microkit.h>
+#include <sel4/sel4.h>
+#include <stdint.h>
+#include "vspace.h"
+
+microkit_uint64_t walk_table(microkit_uint64_t *start, uintptr_t addr, int lvl)
+{
+    // Get the 9 bit index for this level.
+    uintptr_t index = 0;
+    if (lvl == 1) {
+        // Index into the PUD
+        index = (addr & ((uintptr_t)0x1ff << 30)) >> 30;
+    } else if (lvl == 2) {
+        // Index into the PD
+        index = (addr & ((uintptr_t)0x1ff << 21)) >> 21;
+    } else if (lvl == 3) {
+        // Index into the PT
+        index = (addr & ((uintptr_t)0x1ff << 12)) >> 12;
+    }
+    if (lvl == 3) {
+       return start[index];
+    } else {
+        walk_table(&table_data[start[index]/8], addr, lvl + 1);
+    }
+}
+
+seL4_Word get_page(uint8_t child_id, uintptr_t addr) {
+    microkit_uint64_t page = walk_table(&table_data[table_metadata[child_id]/8], addr, 0);
+    return page;
+}
+
+uint32_t read_word(uint16_t client, uintptr_t addr, seL4_Word *val, seL4_Word map_addr) {
+    seL4_Word page = get_page(client, addr);
+    if (page == 0 || page == 0xffffffffffffffff) {
+        return 1;
+    }
+
+    // Mapping into vaddr 0x900000, this corresponds to a memory region created in the metaprogram
+    // at the same address and 1 page in size.
+    int err = seL4_ARM_Page_Map(page, VSPACE_CAP, map_addr, seL4_AllRights, seL4_ARM_Default_VMAttributes | seL4_ARM_ExecuteNever);
+
+    if (err) {
+        microkit_dbg_puts("We got an error when mapping page in read_word()");
+    }
+
+    uint64_t *ptr_to_page = (uint64_t *) (map_addr + (addr & 0xfff));
+    *val = *ptr_to_page;
+    return 0;
+}
+
+uint32_t write_word(uint16_t client, uintptr_t addr, seL4_Word val, seL4_Word map_addr) {
+    seL4_Word page = get_page(client, addr);
+    if (page == 0 || page == 0xffffffffffffffff) {
+        return 1;
+    }
+
+    // Mapping into vaddr 0x900000, this corresponds to a memory region created in the metaprogram
+    // at the same address and 1 page in size.
+    int err = seL4_ARM_Page_Map(page, VSPACE_CAP, map_addr, seL4_AllRights, seL4_ARM_Default_VMAttributes | seL4_ARM_ExecuteNever);
+
+    if (err) {
+        microkit_dbg_puts("We got an error when mapping page in write_word()");
+    }
+
+    uint64_t *ptr_to_page = (uint64_t *) (map_addr + (addr & 0xfff));
+    *ptr_to_page = val;
+    return 0;
+}

--- a/libvspace/vspace.c
+++ b/libvspace/vspace.c
@@ -4,11 +4,27 @@
 #include "vspace.h"
 #include <sddf/util/printf.h>
 
-uint64_t walk_table(uint64_t *start, uintptr_t addr, int lvl)
+#define AARCH64_SMALL_PAGE_SIZE 0x1000
+#define AARCH64_LARGE_PAGE_SIZE 0x200000
+
+uint64_t small_mapping_region = 0;
+uint64_t large_mapping_region = 0;
+
+typedef struct table_meta_data {
+    uint64_t table_data_base;
+    uint64_t pgd[64];
+} table_metadata_t;
+
+table_metadata_t table_metadata;
+
+uint64_t walk_table(uint64_t *start, uintptr_t addr, int lvl, uint64_t *page_size)
 {
     // Get the 9 bit index for this level.
     uintptr_t index = 0;
-    if (lvl == 1) {
+    if (lvl == 0) {
+        // Index into the PGD
+        index = (addr & ((uintptr_t)0x1ff << 39)) >> 39;
+    } else if (lvl == 1) {
         // Index into the PUD
         index = (addr & ((uintptr_t)0x1ff << 30)) >> 30;
     } else if (lvl == 2) {
@@ -24,22 +40,41 @@ uint64_t walk_table(uint64_t *start, uintptr_t addr, int lvl)
     }
 
     if (lvl == 3) {
+        *page_size = AARCH64_SMALL_PAGE_SIZE;
         return start[index];
-    } else {
-        walk_table((uint64_t *) (table_metadata.table_data_base + start[index]), addr, lvl + 1);
+    } else if (lvl == 2) {
+        // Check if we have a large page.
+        if (start[index] & ((uint64_t) 1 << 63)) {
+            *page_size = AARCH64_LARGE_PAGE_SIZE;
+            return (start[index] << 1) >> 1;
+        }
     }
+
+    walk_table((uint64_t *) (table_metadata.table_data_base + start[index]), addr, lvl + 1, page_size);
 }
 
-seL4_Word get_page(uint8_t child_id, uintptr_t addr) {
-    uint64_t page = walk_table((uint64_t *) (table_metadata.table_data_base + table_metadata.pgd[child_id]), addr, 0);
+seL4_Word get_page(uint8_t child_id, uintptr_t addr, uint64_t *page_size)
+{
+    uint64_t page = walk_table((uint64_t *) (table_metadata.table_data_base + table_metadata.pgd[child_id]), addr, 0, page_size);
     return page;
 }
 
-uint32_t read_word(uint16_t client, uintptr_t addr, seL4_Word *val, seL4_Word map_addr) {
-    seL4_Word page = get_page(client, addr);
-    if (page == 0 || page == 0xffffffffffffffff) {
+uint32_t libvspace_read_word(uint16_t client, uintptr_t addr, seL4_Word *val)
+{
+    uint64_t page_size = 0;
+    seL4_Word page = get_page(client, addr, &page_size);
+    if ((page == 0 || page == 0xffffffffffffffff) || page_size == 0) {
         return 1;
     }
+
+    seL4_Word map_addr;
+
+    if (page_size == AARCH64_LARGE_PAGE_SIZE) {
+        map_addr = large_mapping_region;
+    } else {
+        map_addr = small_mapping_region;
+    }
+
     // Mapping into vaddr 0x900000, this corresponds to a memory region created in the metaprogram
     // at the same address and 1 page in size.
     int err = seL4_ARM_Page_Map(page, VSPACE_CAP, map_addr, seL4_AllRights, seL4_ARM_Default_VMAttributes | seL4_ARM_ExecuteNever);
@@ -48,15 +83,25 @@ uint32_t read_word(uint16_t client, uintptr_t addr, seL4_Word *val, seL4_Word ma
         sddf_dprintf("We got an error when mapping page in read_word()");
     }
 
-    uint64_t *ptr_to_page = (uint64_t *) (map_addr + (addr & 0xfff));
+    uint64_t *ptr_to_page = (uint64_t *) (map_addr + (addr & (page_size - 1)));
     *val = *ptr_to_page;
     return 0;
 }
 
-uint32_t write_word(uint16_t client, uintptr_t addr, seL4_Word val, seL4_Word map_addr) {
-    seL4_Word page = get_page(client, addr);
-    if (page == 0 || page == 0xffffffffffffffff) {
+uint32_t libvspace_write_word(uint16_t client, uintptr_t addr, seL4_Word val)
+{
+    uint64_t page_size = 0;
+    seL4_Word page = get_page(client, addr, &page_size);
+    if ((page == 0 || page == 0xffffffffffffffff) || page_size == 0) {
         return 1;
+    }
+
+    seL4_Word map_addr;
+
+    if (page_size == AARCH64_LARGE_PAGE_SIZE) {
+        map_addr = large_mapping_region;
+    } else {
+        map_addr = small_mapping_region;
     }
 
     // Mapping into vaddr 0x900000, this corresponds to a memory region created in the metaprogram
@@ -67,12 +112,22 @@ uint32_t write_word(uint16_t client, uintptr_t addr, seL4_Word val, seL4_Word ma
         sddf_dprintf("We got an error when mapping page in write_word()");
     }
 
-    uint64_t *ptr_to_page = (uint64_t *) (map_addr + (addr & 0xfff));
+    uint64_t *ptr_to_page = (uint64_t *) (map_addr + (addr & (page_size - 1)));
     *ptr_to_page = val;
 
     asm("dmb sy");
-    seL4_ARM_VSpace_CleanInvalidate_Data(VSPACE_CAP, map_addr + (addr & 0xfff), map_addr + (addr & 0xfff) + sizeof(uint64_t));
+    seL4_ARM_VSpace_CleanInvalidate_Data(VSPACE_CAP, map_addr + (addr & (page_size - 1)), map_addr + (addr & (page_size - 1)) + sizeof(uint64_t));
     seL4_ARM_VSpace_Unify_Instruction(BASE_VSPACE_CAP + client, addr , addr + sizeof(uint64_t));
 
     return 0;
+}
+
+void libvspace_set_small_mapping_region(uint64_t vaddr)
+{
+    small_mapping_region = vaddr;
+}
+
+void libvspace_set_large_mapping_region(uint64_t vaddr)
+{
+    large_mapping_region = vaddr;
 }

--- a/libvspace/vspace.c
+++ b/libvspace/vspace.c
@@ -2,8 +2,9 @@
 #include <sel4/sel4.h>
 #include <stdint.h>
 #include "vspace.h"
+#include <sddf/util/printf.h>
 
-microkit_uint64_t walk_table(microkit_uint64_t *start, uintptr_t addr, int lvl)
+uint64_t walk_table(uint64_t *start, uintptr_t addr, int lvl)
 {
     // Get the 9 bit index for this level.
     uintptr_t index = 0;
@@ -17,15 +18,20 @@ microkit_uint64_t walk_table(microkit_uint64_t *start, uintptr_t addr, int lvl)
         // Index into the PT
         index = (addr & ((uintptr_t)0x1ff << 12)) >> 12;
     }
+
+    if (start[index] == 0xffffffffffffffff) {
+        return 0xffffffffffffffff;
+    }
+
     if (lvl == 3) {
-       return start[index];
+        return start[index];
     } else {
-        walk_table(&table_data[start[index]/8], addr, lvl + 1);
+        walk_table((uint64_t *) (table_metadata.table_data_base + start[index]), addr, lvl + 1);
     }
 }
 
 seL4_Word get_page(uint8_t child_id, uintptr_t addr) {
-    microkit_uint64_t page = walk_table(&table_data[table_metadata[child_id]/8], addr, 0);
+    uint64_t page = walk_table((uint64_t *) (table_metadata.table_data_base + table_metadata.pgd[child_id]), addr, 0);
     return page;
 }
 
@@ -34,13 +40,12 @@ uint32_t read_word(uint16_t client, uintptr_t addr, seL4_Word *val, seL4_Word ma
     if (page == 0 || page == 0xffffffffffffffff) {
         return 1;
     }
-
     // Mapping into vaddr 0x900000, this corresponds to a memory region created in the metaprogram
     // at the same address and 1 page in size.
     int err = seL4_ARM_Page_Map(page, VSPACE_CAP, map_addr, seL4_AllRights, seL4_ARM_Default_VMAttributes | seL4_ARM_ExecuteNever);
 
     if (err) {
-        microkit_dbg_puts("We got an error when mapping page in read_word()");
+        sddf_dprintf("We got an error when mapping page in read_word()");
     }
 
     uint64_t *ptr_to_page = (uint64_t *) (map_addr + (addr & 0xfff));
@@ -56,13 +61,18 @@ uint32_t write_word(uint16_t client, uintptr_t addr, seL4_Word val, seL4_Word ma
 
     // Mapping into vaddr 0x900000, this corresponds to a memory region created in the metaprogram
     // at the same address and 1 page in size.
-    int err = seL4_ARM_Page_Map(page, VSPACE_CAP, map_addr, seL4_AllRights, seL4_ARM_Default_VMAttributes | seL4_ARM_ExecuteNever);
+    int err = seL4_ARM_Page_Map(page, VSPACE_CAP, map_addr, seL4_AllRights, seL4_ARM_Default_VMAttributes);
 
     if (err) {
-        microkit_dbg_puts("We got an error when mapping page in write_word()");
+        sddf_dprintf("We got an error when mapping page in write_word()");
     }
 
     uint64_t *ptr_to_page = (uint64_t *) (map_addr + (addr & 0xfff));
     *ptr_to_page = val;
+
+    asm("dmb sy");
+    seL4_ARM_VSpace_CleanInvalidate_Data(VSPACE_CAP, map_addr + (addr & 0xfff), map_addr + (addr & 0xfff) + sizeof(uint64_t));
+    seL4_ARM_VSpace_Unify_Instruction(BASE_VSPACE_CAP + client, addr , addr + sizeof(uint64_t));
+
     return 0;
 }

--- a/libvspace/vspace.c
+++ b/libvspace/vspace.c
@@ -8,8 +8,15 @@
 #define AARCH64_SMALL_PAGE_SIZE 0x1000
 #define AARCH64_LARGE_PAGE_SIZE 0x200000
 
+#define ALIGN_4K(x)     (((uintptr_t)(x) + (uintptr_t)(0xFFF)) & ~(uintptr_t)(0xFFF))
+#define ALIGN_2MB(x)    (((uintptr_t)(x) + (uintptr_t)(0x1FFFFF)) & ~(uintptr_t)(0x1FFFFF))
+#define MIN(i, j) (((i) < (j)) ? (i) : (j))
+#define MAX(i, j) (((i) > (j)) ? (i) : (j))
+
 uint64_t small_mapping_region = 0;
 uint64_t large_mapping_region = 0;
+
+bool libvspace_initialised = false;
 
 typedef struct table_meta_data {
     uint64_t table_data_base;
@@ -61,60 +68,68 @@ seL4_Word get_page(uint8_t child_id, uintptr_t addr, uint64_t *page_size)
 }
 
 uint32_t libvspace_read_bytes(uint16_t client, uintptr_t addr, char *buff, uint64_t nbytes) {
-    uint64_t page_size = 0;
-    seL4_Word page = get_page(client, addr, &page_size);
-    if ((page == 0 || page == 0xffffffffffffffff) || page_size == 0) {
+    if (!libvspace_initialised) {
+        sddf_dprintf("'libvspace_read_bytes': ERROR libvspace not initialised!\n");
         return 1;
     }
+    // These values will be set in the fist iteration of the read loop
+    seL4_Word map_addr = 0;
+    uint64_t page_size = 0;
+    size_t page_aligned_up_curr_addr = 0;
 
-    seL4_Word map_addr;
+    size_t bytes_to_read = nbytes;
+    uintptr_t curr_addr = addr;
+    char *curr_buff_addr = buff;
 
-    if (page_size == AARCH64_LARGE_PAGE_SIZE) {
-        map_addr = large_mapping_region;
-    } else {
-        map_addr = small_mapping_region;
-    }
+    bool mapped_first_page = false;
 
-    int err = seL4_ARM_Page_Map(page, VSPACE_CAP, map_addr, seL4_AllRights, seL4_ARM_Default_VMAttributes | seL4_ARM_ExecuteNever);
-
-    if (err) {
-        sddf_dprintf("We got an error when mapping page in read_word() at map addr: 0x%lx\n", map_addr);
-        return err;
-    }
-
-    // We are going to copy nytes into the buff iteratively
-    char *curr_addr = (char *) (map_addr + (addr & (page_size - 1)));
-
-    for (int i = 0; i < nbytes; i++) {
-        // Don't want to do this on the first page?
-        if ((uintptr_t) curr_addr % page_size == 0) {
-            // get the next page
-            page = get_page(client, (uintptr_t)addr, &page_size);
+    while (bytes_to_read != 0) {
+        if (!mapped_first_page || (uintptr_t) curr_addr % page_size == 0) {
+            seL4_Word page = get_page(client, (uintptr_t)addr, &page_size);
             if ((page == 0 || page == 0xffffffffffffffff) || page_size == 0) {
                 sddf_dprintf("Failed to read byte at addr: 0x%p after remap\n", addr);
                 return 1;
             }
-
-            err = seL4_ARM_Page_Map(page, VSPACE_CAP, map_addr, seL4_AllRights, seL4_ARM_Default_VMAttributes | seL4_ARM_ExecuteNever);
+            if (page_size == AARCH64_LARGE_PAGE_SIZE) {
+                map_addr = large_mapping_region;
+                page_aligned_up_curr_addr = ALIGN_2MB(curr_addr + 1);
+            } else {
+                map_addr = small_mapping_region;
+                // This macro aligns up. We add 1 to curr addr as we want to get
+                // to the the next page boundary if we are currently at the start of a 
+                // page boundary.
+                page_aligned_up_curr_addr = ALIGN_4K(curr_addr + 1);
+            }
+            int err = seL4_ARM_Page_Map(page, VSPACE_CAP, map_addr, seL4_AllRights, seL4_ARM_Default_VMAttributes | seL4_ARM_ExecuteNever);
 
             if (err) {
                 sddf_dprintf("We got an error when mapping page in read_word() at map addr: 0x%lx\n", map_addr);
                 return err;
             }
-
-            // reset the cur addr to the start of the memory region
-            curr_addr = (char *) map_addr;
+            mapped_first_page = true;
         }
-        buff[i] = *curr_addr;
-        curr_addr++;
-        addr++;
+
+        // Get the amount of space remaining in this page.
+        size_t space = page_aligned_up_curr_addr - curr_addr;
+        // We can only read at most the space remaining in the page. We
+        // will read whatever the minimum of these two values are.
+        size_t current_read = MIN(bytes_to_read, space);
+        // Calculate the offset into the map addr page
+        char *ptr_to_page = (char *) (map_addr + (curr_addr & (page_size - 1)));
+        curr_addr += current_read;
+        bytes_to_read = bytes_to_read - current_read;
+
+        memcpy(curr_buff_addr, ptr_to_page, current_read);
     }
     return 0;
 }
 
-
 uint32_t libvspace_read_word(uint16_t client, uintptr_t addr, char *val)
 {
+    if (!libvspace_initialised) {
+        sddf_dprintf("'libvspace_read_word': ERROR libvspace not initialised!\n");
+        return 1;
+    }
     uint64_t page_size = 0;
     seL4_Word page = get_page(client, addr, &page_size);
     if ((page == 0 || page == 0xffffffffffffffff) || page_size == 0) {
@@ -145,6 +160,10 @@ uint32_t libvspace_read_word(uint16_t client, uintptr_t addr, char *val)
 
 uint32_t libvspace_write_word(uint16_t client, uintptr_t addr, seL4_Word val)
 {
+    if (!libvspace_initialised) {
+        sddf_dprintf("'libvspace_write_word': ERROR libvspace not initialised!\n");
+        return 1;
+    }
     uint64_t page_size = 0;
     seL4_Word page = get_page(client, addr, &page_size);
     if ((page == 0 || page == 0xffffffffffffffff) || page_size == 0) {
@@ -215,9 +234,13 @@ uint32_t libvspace_write_page(uint16_t client, uintptr_t addr, char *bytes, size
     return 0;
 }
 
-#define ALIGN_4K(x)     (((uintptr_t)(x) + (uintptr_t)(0xFFF)) & ~(uintptr_t)(0xFFF))
-
 uint32_t libvspace_write_bytes(uint16_t client, uintptr_t start_addr, char *bytes, uint64_t nbytes) {
+    if (!libvspace_initialised) {
+        sddf_dprintf("'libvspace_write_bytes': ERROR libvspace not initialised!\n");
+        return 1;
+    }
+
+    // @kwinter: All this logic assumes we are working with small pages.
     size_t page_size = 0x1000;
     size_t bytes_to_transfer = nbytes;
     size_t page_aligned_start_addr = ALIGN_4K(start_addr);
@@ -257,12 +280,9 @@ uint32_t libvspace_write_bytes(uint16_t client, uintptr_t start_addr, char *byte
     return nbytes - bytes_to_transfer;
 }
 
-void libvspace_set_small_mapping_region(uint64_t vaddr)
+void libvspace_init_mapping_regions(uint64_t small_map_vaddr, uint64_t large_map_vaddr)
 {
-    small_mapping_region = vaddr;
-}
-
-void libvspace_set_large_mapping_region(uint64_t vaddr)
-{
-    large_mapping_region = vaddr;
+    small_mapping_region = small_map_vaddr;
+    large_mapping_region = large_map_vaddr;
+    libvspace_initialised = true;
 }

--- a/libvspace/vspace.c
+++ b/libvspace/vspace.c
@@ -60,7 +60,60 @@ seL4_Word get_page(uint8_t child_id, uintptr_t addr, uint64_t *page_size)
     return page;
 }
 
-uint32_t libvspace_read_word(uint16_t client, uintptr_t addr, seL4_Word *val)
+uint32_t libvspace_read_bytes(uint16_t client, uintptr_t addr, char *buff, uint64_t nbytes) {
+    uint64_t page_size = 0;
+    seL4_Word page = get_page(client, addr, &page_size);
+    if ((page == 0 || page == 0xffffffffffffffff) || page_size == 0) {
+        return 1;
+    }
+
+    seL4_Word map_addr;
+
+    if (page_size == AARCH64_LARGE_PAGE_SIZE) {
+        map_addr = large_mapping_region;
+    } else {
+        map_addr = small_mapping_region;
+    }
+
+    int err = seL4_ARM_Page_Map(page, VSPACE_CAP, map_addr, seL4_AllRights, seL4_ARM_Default_VMAttributes | seL4_ARM_ExecuteNever);
+
+    if (err) {
+        sddf_dprintf("We got an error when mapping page in read_word() at map addr: 0x%lx\n", map_addr);
+        return err;
+    }
+
+    // We are going to copy nytes into the buff iteratively
+    char *curr_addr = (char *) (map_addr + (addr & (page_size - 1)));
+
+    for (int i = 0; i < nbytes; i++) {
+        // Don't want to do this on the first page?
+        if ((uintptr_t) curr_addr % page_size == 0) {
+            // get the next page
+            page = get_page(client, (uintptr_t)addr, &page_size);
+            if ((page == 0 || page == 0xffffffffffffffff) || page_size == 0) {
+                sddf_dprintf("Failed to read byte at addr: 0x%p after remap\n", addr);
+                return 1;
+            }
+
+            err = seL4_ARM_Page_Map(page, VSPACE_CAP, map_addr, seL4_AllRights, seL4_ARM_Default_VMAttributes | seL4_ARM_ExecuteNever);
+
+            if (err) {
+                sddf_dprintf("We got an error when mapping page in read_word() at map addr: 0x%lx\n", map_addr);
+                return err;
+            }
+
+            // reset the cur addr to the start of the memory region
+            curr_addr = (char *) map_addr;
+        }
+        buff[i] = *curr_addr;
+        curr_addr++;
+        addr++;
+    }
+    return 0;
+}
+
+
+uint32_t libvspace_read_word(uint16_t client, uintptr_t addr, char *val)
 {
     uint64_t page_size = 0;
     seL4_Word page = get_page(client, addr, &page_size);
@@ -86,7 +139,7 @@ uint32_t libvspace_read_word(uint16_t client, uintptr_t addr, seL4_Word *val)
     }
 
     char *ptr_to_page = (char *) (map_addr + (addr & (page_size - 1)));
-    memcpy((char *) val, ptr_to_page, 8);
+    memcpy((char *) val, ptr_to_page, sizeof(seL4_Word));
     return 0;
 }
 
@@ -106,8 +159,6 @@ uint32_t libvspace_write_word(uint16_t client, uintptr_t addr, seL4_Word val)
         map_addr = small_mapping_region;
     }
 
-    // Mapping into vaddr 0x900000, this corresponds to a memory region created in the metaprogram
-    // at the same address and 1 page in size.
     int err = seL4_ARM_Page_Map(page, VSPACE_CAP, map_addr, seL4_AllRights, seL4_ARM_Default_VMAttributes);
 
     if (err) {
@@ -123,6 +174,87 @@ uint32_t libvspace_write_word(uint16_t client, uintptr_t addr, seL4_Word val)
     seL4_ARM_VSpace_Unify_Instruction(BASE_VSPACE_CAP + client, addr , addr + sizeof(uint64_t));
 
     return 0;
+}
+
+
+uint32_t libvspace_write_page(uint16_t client, uintptr_t addr, char *bytes, size_t nbytes)
+{
+    uint64_t page_size = 0;
+    seL4_Word page = get_page(client, addr, &page_size);
+    // sddf_dprintf("page: %lu\n", page);
+    if ((page == 0 || page == 0xffffffffffffffff) || page_size == 0) {
+        return 1;
+    }
+
+    seL4_Word map_addr;
+
+    if (page_size == AARCH64_LARGE_PAGE_SIZE) {
+        map_addr = large_mapping_region;
+    } else {
+        map_addr = small_mapping_region;
+    }
+
+    int err = seL4_ARM_Page_Map(page, VSPACE_CAP, map_addr, seL4_AllRights, seL4_ARM_Default_VMAttributes);
+
+    if (err) {
+        sddf_dprintf("We got an error when mapping page in write_word()\n");
+        __builtin_trap();
+    }
+
+    char *ptr_to_page = (char *) (map_addr + (addr & (page_size - 1)));
+    if (bytes != NULL) {
+        memcpy(ptr_to_page, bytes, nbytes);
+    } else {
+        memset(ptr_to_page, 0, nbytes);
+    }
+
+    asm("dmb sy");
+    seL4_ARM_VSpace_CleanInvalidate_Data(VSPACE_CAP, map_addr + (addr & (page_size - 1)), map_addr + (addr & (page_size - 1)) + sizeof(uint64_t));
+    seL4_ARM_VSpace_Unify_Instruction(BASE_VSPACE_CAP + client, addr , addr + sizeof(uint64_t));
+
+    return 0;
+}
+
+#define ALIGN_4K(x)     (((uintptr_t)(x) + (uintptr_t)(0xFFF)) & ~(uintptr_t)(0xFFF))
+
+uint32_t libvspace_write_bytes(uint16_t client, uintptr_t start_addr, char *bytes, uint64_t nbytes) {
+    size_t page_size = 0x1000;
+    size_t bytes_to_transfer = nbytes;
+    size_t page_aligned_start_addr = ALIGN_4K(start_addr);
+    size_t space = page_aligned_start_addr - start_addr;
+
+    if (space > 0) {
+        if (nbytes >= space) {
+            uint32_t ret = libvspace_write_page(client, start_addr, bytes, space);
+            assert(!ret);
+            bytes_to_transfer -= space;
+        } else {
+            uint32_t ret = libvspace_write_page(client, start_addr, bytes, nbytes);
+            assert(!ret);
+            return 0;
+        }
+    }
+
+    size_t n_pages = (bytes_to_transfer / page_size) + 1;
+    for (int i = 0; i < n_pages; i++) {
+        size_t transfer_nbytes = 0;
+        if (bytes_to_transfer < page_size) {
+            // This case should only be for the last page
+            transfer_nbytes = bytes_to_transfer;
+        } else {
+            transfer_nbytes = page_size;
+        }
+        uint32_t ret;
+        if (bytes != NULL) {
+            ret = libvspace_write_page(client, page_aligned_start_addr + (i * page_size), bytes + (i * page_size) + (start_addr % page_size), transfer_nbytes);
+        } else {
+            ret = libvspace_write_page(client, page_aligned_start_addr + (i * page_size), NULL, transfer_nbytes);
+        }
+        assert(!ret);
+
+        bytes_to_transfer -= transfer_nbytes;
+    }
+    return nbytes - bytes_to_transfer;
 }
 
 void libvspace_set_small_mapping_region(uint64_t vaddr)

--- a/libvspace/vspace.c
+++ b/libvspace/vspace.c
@@ -3,6 +3,7 @@
 #include <stdint.h>
 #include "vspace.h"
 #include <sddf/util/printf.h>
+#include <sddf/util/util.h>
 
 #define AARCH64_SMALL_PAGE_SIZE 0x1000
 #define AARCH64_LARGE_PAGE_SIZE 0x200000
@@ -50,7 +51,7 @@ uint64_t walk_table(uint64_t *start, uintptr_t addr, int lvl, uint64_t *page_siz
         }
     }
 
-    walk_table((uint64_t *) (table_metadata.table_data_base + start[index]), addr, lvl + 1, page_size);
+    return walk_table((uint64_t *) (table_metadata.table_data_base + start[index]), addr, lvl + 1, page_size);
 }
 
 seL4_Word get_page(uint8_t child_id, uintptr_t addr, uint64_t *page_size)
@@ -80,11 +81,12 @@ uint32_t libvspace_read_word(uint16_t client, uintptr_t addr, seL4_Word *val)
     int err = seL4_ARM_Page_Map(page, VSPACE_CAP, map_addr, seL4_AllRights, seL4_ARM_Default_VMAttributes | seL4_ARM_ExecuteNever);
 
     if (err) {
-        sddf_dprintf("We got an error when mapping page in read_word()");
+        sddf_dprintf("We got an error when mapping page in read_word() at map addr: 0x%lx\n", map_addr);
+        return err;
     }
 
-    uint64_t *ptr_to_page = (uint64_t *) (map_addr + (addr & (page_size - 1)));
-    *val = *ptr_to_page;
+    char *ptr_to_page = (char *) (map_addr + (addr & (page_size - 1)));
+    memcpy((char *) val, ptr_to_page, 8);
     return 0;
 }
 
@@ -109,11 +111,12 @@ uint32_t libvspace_write_word(uint16_t client, uintptr_t addr, seL4_Word val)
     int err = seL4_ARM_Page_Map(page, VSPACE_CAP, map_addr, seL4_AllRights, seL4_ARM_Default_VMAttributes);
 
     if (err) {
-        sddf_dprintf("We got an error when mapping page in write_word()");
+        sddf_dprintf("We got an error when mapping page in write_word() at map addr: 0x%lx\n", map_addr);
+        return err;
     }
 
-    uint64_t *ptr_to_page = (uint64_t *) (map_addr + (addr & (page_size - 1)));
-    *ptr_to_page = val;
+    char *ptr_to_page = (char *) (map_addr + (addr & (page_size - 1)));
+    memcpy(ptr_to_page, (char *) &val, 8);
 
     asm("dmb sy");
     seL4_ARM_VSpace_CleanInvalidate_Data(VSPACE_CAP, map_addr + (addr & (page_size - 1)), map_addr + (addr & (page_size - 1)) + sizeof(uint64_t));

--- a/libvspace/vspace.h
+++ b/libvspace/vspace.h
@@ -2,8 +2,12 @@
 
 #define NUM_DEBUGEES 2
 
-microkit_uint64_t table_metadata[64];
-microkit_uint64_t table_data[0x800 * (NUM_DEBUGEES + 100)];
+typedef struct table_meta_data {
+    uint64_t table_data_base;
+    uint64_t pgd[64];
+} table_metadata_t;
+
+table_metadata_t table_metadata;
 
 uint32_t read_word(uint16_t client, uintptr_t addr, seL4_Word *val, seL4_Word map_addr);
 uint32_t write_word(uint16_t client, uintptr_t addr, seL4_Word val, seL4_Word map_addr);

--- a/libvspace/vspace.h
+++ b/libvspace/vspace.h
@@ -1,13 +1,10 @@
+#pragma once
+
 #include <microkit.h>
 
 #define NUM_DEBUGEES 2
 
-typedef struct table_meta_data {
-    uint64_t table_data_base;
-    uint64_t pgd[64];
-} table_metadata_t;
-
-table_metadata_t table_metadata;
-
-uint32_t read_word(uint16_t client, uintptr_t addr, seL4_Word *val, seL4_Word map_addr);
-uint32_t write_word(uint16_t client, uintptr_t addr, seL4_Word val, seL4_Word map_addr);
+uint32_t libvspace_read_word(uint16_t client, uintptr_t addr, seL4_Word *val);
+uint32_t libvspace_write_word(uint16_t client, uintptr_t addr, seL4_Word val);
+void libvspace_set_small_mapping_region(uint64_t vaddr);
+void libvspace_set_large_mapping_region(uint64_t vaddr);

--- a/libvspace/vspace.h
+++ b/libvspace/vspace.h
@@ -1,0 +1,9 @@
+#include <microkit.h>
+
+#define NUM_DEBUGEES 2
+
+microkit_uint64_t table_metadata[64];
+microkit_uint64_t table_data[0x800 * (NUM_DEBUGEES + 100)];
+
+uint32_t read_word(uint16_t client, uintptr_t addr, seL4_Word *val, seL4_Word map_addr);
+uint32_t write_word(uint16_t client, uintptr_t addr, seL4_Word val, seL4_Word map_addr);

--- a/libvspace/vspace.h
+++ b/libvspace/vspace.h
@@ -2,11 +2,8 @@
 
 #include <microkit.h>
 
-#define NUM_DEBUGEES 2
-
 uint32_t libvspace_read_word(uint16_t client, uintptr_t addr, char *val);
 uint32_t libvspace_read_bytes(uint16_t client, uintptr_t start_addr, char *buff, uint64_t nbytes);
 uint32_t libvspace_write_word(uint16_t client, uintptr_t addr, seL4_Word val);
 uint32_t libvspace_write_bytes(uint16_t client, uintptr_t start_addr, char *bytes, uint64_t nbytes);
-void libvspace_set_small_mapping_region(uint64_t vaddr);
-void libvspace_set_large_mapping_region(uint64_t vaddr);
+void libvspace_init_mapping_regions(uint64_t small_map_vaddr, uint64_t large_map_vaddr);

--- a/libvspace/vspace.h
+++ b/libvspace/vspace.h
@@ -4,7 +4,9 @@
 
 #define NUM_DEBUGEES 2
 
-uint32_t libvspace_read_word(uint16_t client, uintptr_t addr, seL4_Word *val);
+uint32_t libvspace_read_word(uint16_t client, uintptr_t addr, char *val);
+uint32_t libvspace_read_bytes(uint16_t client, uintptr_t start_addr, char *buff, uint64_t nbytes);
 uint32_t libvspace_write_word(uint16_t client, uintptr_t addr, seL4_Word val);
+uint32_t libvspace_write_bytes(uint16_t client, uintptr_t start_addr, char *bytes, uint64_t nbytes);
 void libvspace_set_small_mapping_region(uint64_t vaddr);
 void libvspace_set_large_mapping_region(uint64_t vaddr);

--- a/src/arch/arm/64/gdb.c
+++ b/src/arch/arm/64/gdb.c
@@ -116,7 +116,7 @@ bool set_software_breakpoint(gdb_inferior_t *inferior, seL4_Word address) {
     tmp.addr = address;
 
     seL4_Word ret;
-    uint32_t err = read_word(inferior->gdb_id, address, &ret);
+    uint32_t err = read_word(inferior->gdb_id, address, &ret, 0x900000);
     if (err) {
         microkit_dbg_puts("We got an error when trying to read address - 1\n");
         return false;
@@ -127,7 +127,7 @@ bool set_software_breakpoint(gdb_inferior_t *inferior, seL4_Word address) {
     /* Overwrite the address with the instruction but preserve everything else */
     ret = (seL4_Word) AARCH64_BREAK_KGDB_DYN_DBG | (0xFFFFFFFF00000000 & ret);
 
-    err = write_word(inferior->gdb_id, address, ret);
+    err = write_word(inferior->gdb_id, address, ret, 0x900000);
     if (err) {
         microkit_dbg_puts("We got an error when trying to write to address - 2\n");
         return false;
@@ -144,14 +144,14 @@ bool set_software_breakpoint(gdb_inferior_t *inferior, seL4_Word address) {
 
     /* Too many sw breakpoints have been set */
     // @alwin: return value
-    err = write_word(inferior->gdb_id, address, tmp.orig_word);
+    err = write_word(inferior->gdb_id, address, tmp.orig_word, 0x900000);
     return false;
 }
 
 bool unset_software_breakpoint(gdb_inferior_t *inferior, seL4_Word address) {
     for (int i = 0; i < MAX_SW_BREAKS; i++) {
         if (inferior->software_breakpoints[i].addr == address && inferior->software_breakpoints[i].set) {
-            int err = write_word(inferior->gdb_id, address, inferior->software_breakpoints[i].orig_word);
+            int err = write_word(inferior->gdb_id, address, inferior->software_breakpoints[i].orig_word, 0x900000);
             if (err) {
                 microkit_dbg_puts("We got an error when trying to write to address - 9\n");
                 return false;
@@ -299,7 +299,6 @@ bool enable_single_step(gdb_thread_t *thread) {
     // if (inferior->ss_enabled) {
     //     return false;
     // }
-
     thread->ss_enabled = true;
     seL4_TCB_ConfigureSingleStepping(thread->tcb, 0, 1);
     return true;
@@ -324,7 +323,7 @@ char *inf_mem2hex(gdb_thread_t *thread, seL4_Word mem, char *buf, int size, seL4
     for (i = 0; i < size; i++) {
         if (i % sizeof(seL4_Word) == 0) {
             seL4_Word ret = 0;
-            uint32_t err = read_word(thread->inferior->gdb_id, mem, &ret);
+            uint32_t err = read_word(thread->inferior->gdb_id, mem, &ret, 0x900000);
             if (err) {
                 *error = err;
                 return NULL;
@@ -357,7 +356,7 @@ seL4_Word inf_hex2mem(gdb_thread_t *thread, char *buf, seL4_Word mem, int size)
         if (i % sizeof(seL4_Word) == 0) {
 
             seL4_Word ret;
-            uint32_t err = read_word(thread->inferior->gdb_id, mem, &ret);
+            uint32_t err = read_word(thread->inferior->gdb_id, mem, &ret, 0x900000);
             if (err) {
                 return (mem + i);
             }
@@ -370,7 +369,7 @@ seL4_Word inf_hex2mem(gdb_thread_t *thread, char *buf, seL4_Word mem, int size)
         *(((char *) &curr_word) + (i % sizeof(seL4_Word))) = c;
 
         if (i % sizeof(seL4_Word) == sizeof(seL4_Word) - 1 || i == size - 1) {
-            int err = write_word(thread->inferior->gdb_id, mem + (i/sizeof(seL4_Word)), curr_word);
+            int err = write_word(thread->inferior->gdb_id, mem + (i/sizeof(seL4_Word)), curr_word, 0x900000);
             if (err) {
                 return (mem + i);
             }

--- a/src/arch/arm/64/gdb.c
+++ b/src/arch/arm/64/gdb.c
@@ -19,64 +19,6 @@
 #define AARCH64_BREAK_KGDB_DYN_DBG  \
     (AARCH64_BREAK_MON | (KGDB_DYN_DBG_BRK_IMM << 5))
 
-#define VSPACE_CAP 3
-
-// Define table data regions for our child
-microkit_uint64_t table_metadata[64];
-microkit_uint64_t table_data[0x800 * (2 + 100)];
-
-microkit_uint64_t walk_table(microkit_uint64_t *start, uintptr_t addr, int lvl)
-{
-    // Get the 9 bit index for this level.
-    uintptr_t index = 0;
-    if (lvl == 1) {
-        // Index into the PUD
-        index = (addr & ((uintptr_t)0x1ff << 30)) >> 30;
-    } else if (lvl == 2) {
-        // Index into the PD
-        index = (addr & ((uintptr_t)0x1ff << 21)) >> 21;
-    } else if (lvl == 3) {
-        // Index into the PT
-        index = (addr & ((uintptr_t)0x1ff << 12)) >> 12;
-    }
-    if (lvl == 3) {
-       return start[index];
-    } else {
-        walk_table(&table_data[start[index]/8], addr, lvl + 1);
-    }
-}
-
-seL4_Word get_page(uint8_t child_id, uintptr_t addr) {
-    microkit_uint64_t page = walk_table(&table_data[table_metadata[0]/8], addr, 0);
-    return page;
-}
-
-uint32_t read_word(uint16_t client, uintptr_t addr, seL4_Word *val) {
-    seL4_Word page = get_page(0, addr);
-    if (page == 0 || page == 0xffffffffffffffff) {
-        return 1;
-    }
-    int err = seL4_ARM_Page_Map(page, VSPACE_CAP, 0x600000, seL4_AllRights, seL4_ARM_Default_VMAttributes);
-    if (err) {
-        microkit_dbg_puts("We got an error when mapping page in read_word()");
-    }
-    uint64_t *ptr_to_page = (uint64_t *) (0x600000 + (addr & 0xfff));
-    *val = *ptr_to_page;
-    return 0;
-}
-
-uint32_t write_word(uint16_t client, uintptr_t addr, seL4_Word val) {
-    seL4_Word page = get_page(0, addr);
-    if (page == 0 || page == 0xffffffffffffffff) {
-        return 1;
-    }
-    seL4_ARM_Page_Map(page, VSPACE_CAP, 0x600000, seL4_AllRights, seL4_ARM_Default_VMAttributes);
-
-    uint64_t *ptr_to_page = (uint64_t *) (0x600000 + (addr & 0xfff));
-    *ptr_to_page = val;
-    return 0;
-}
-
 /* Convert registers to a hex string */
 // @alwin: This is rather unpleasant, but the way the seL4_UserContext struct is formatted is annoying
 char *regs2hex(seL4_UserContext *regs, char *buf)

--- a/src/arch/arm/64/gdb.c
+++ b/src/arch/arm/64/gdb.c
@@ -116,7 +116,7 @@ bool set_software_breakpoint(gdb_inferior_t *inferior, seL4_Word address) {
     tmp.addr = address;
 
     seL4_Word ret;
-    uint32_t err = read_word(inferior->gdb_id, address, &ret, 0x900000);
+    uint32_t err = read_word(inferior->id, address, &ret, 0x900000);
     if (err) {
         microkit_dbg_puts("We got an error when trying to read address - 1\n");
         return false;
@@ -127,7 +127,7 @@ bool set_software_breakpoint(gdb_inferior_t *inferior, seL4_Word address) {
     /* Overwrite the address with the instruction but preserve everything else */
     ret = (seL4_Word) AARCH64_BREAK_KGDB_DYN_DBG | (0xFFFFFFFF00000000 & ret);
 
-    err = write_word(inferior->gdb_id, address, ret, 0x900000);
+    err = write_word(inferior->id, address, ret, 0x900000);
     if (err) {
         microkit_dbg_puts("We got an error when trying to write to address - 2\n");
         return false;
@@ -144,14 +144,14 @@ bool set_software_breakpoint(gdb_inferior_t *inferior, seL4_Word address) {
 
     /* Too many sw breakpoints have been set */
     // @alwin: return value
-    err = write_word(inferior->gdb_id, address, tmp.orig_word, 0x900000);
+    err = write_word(inferior->id, address, tmp.orig_word, 0x900000);
     return false;
 }
 
 bool unset_software_breakpoint(gdb_inferior_t *inferior, seL4_Word address) {
     for (int i = 0; i < MAX_SW_BREAKS; i++) {
         if (inferior->software_breakpoints[i].addr == address && inferior->software_breakpoints[i].set) {
-            int err = write_word(inferior->gdb_id, address, inferior->software_breakpoints[i].orig_word, 0x900000);
+            int err = write_word(inferior->id, address, inferior->software_breakpoints[i].orig_word, 0x900000);
             if (err) {
                 microkit_dbg_puts("We got an error when trying to write to address - 9\n");
                 return false;
@@ -323,7 +323,7 @@ char *inf_mem2hex(gdb_thread_t *thread, seL4_Word mem, char *buf, int size, seL4
     for (i = 0; i < size; i++) {
         if (i % sizeof(seL4_Word) == 0) {
             seL4_Word ret = 0;
-            uint32_t err = read_word(thread->inferior->gdb_id, mem, &ret, 0x900000);
+            uint32_t err = read_word(thread->inferior->id, mem, &ret, 0x900000);
             if (err) {
                 *error = err;
                 return NULL;
@@ -356,7 +356,7 @@ seL4_Word inf_hex2mem(gdb_thread_t *thread, char *buf, seL4_Word mem, int size)
         if (i % sizeof(seL4_Word) == 0) {
 
             seL4_Word ret;
-            uint32_t err = read_word(thread->inferior->gdb_id, mem, &ret, 0x900000);
+            uint32_t err = read_word(thread->inferior->id, mem, &ret, 0x900000);
             if (err) {
                 return (mem + i);
             }
@@ -369,7 +369,7 @@ seL4_Word inf_hex2mem(gdb_thread_t *thread, char *buf, seL4_Word mem, int size)
         *(((char *) &curr_word) + (i % sizeof(seL4_Word))) = c;
 
         if (i % sizeof(seL4_Word) == sizeof(seL4_Word) - 1 || i == size - 1) {
-            int err = write_word(thread->inferior->gdb_id, mem + (i/sizeof(seL4_Word)), curr_word, 0x900000);
+            int err = write_word(thread->inferior->id, mem + (i/sizeof(seL4_Word)), curr_word, 0x900000);
             if (err) {
                 return (mem + i);
             }

--- a/src/arch/arm/64/gdb.c
+++ b/src/arch/arm/64/gdb.c
@@ -9,6 +9,8 @@
 #include <sel4/constants.h>
 #include <gdb.h>
 #include <stddef.h>
+#include <printf.h>
+
 #ifndef MICROKIT
 #include <assert.h>
 #endif /* MICROKIT */
@@ -18,6 +20,49 @@
 #define KGDB_DYN_DBG_BRK_IMM        0x400
 #define AARCH64_BREAK_KGDB_DYN_DBG  \
     (AARCH64_BREAK_MON | (KGDB_DYN_DBG_BRK_IMM << 5))
+
+char *regs2print(seL4_UserContext *regs, char *buf)
+{
+    /* First we handle the 64 bit general purpose registers*/
+    printf("Register[x0] value: 0x%lx: \n", regs->x0);
+    printf("Register[x1] value: 0x%lx: \n", regs->x1);
+    printf("Register[x2] value: 0x%lx: \n", regs->x2);
+    printf("Register[x3] value: 0x%lx: \n", regs->x3);
+    printf("Register[x4] value: 0x%lx: \n", regs->x4);
+    printf("Register[x5] value: 0x%lx: \n", regs->x5);
+    printf("Register[x6] value: 0x%lx: \n", regs->x6);
+    printf("Register[x7] value: 0x%lx: \n", regs->x7);
+    printf("Register[x8] value: 0x%lx: \n", regs->x8);
+    printf("Register[x9] value: 0x%lx: \n", regs->x9);
+    printf("Register[x10] value: 0x%lx: \n", regs->x10);
+    printf("Register[x11] value: 0x%lx: \n", regs->x11);
+    printf("Register[x12] value: 0x%lx: \n", regs->x12);
+    printf("Register[x13] value: 0x%lx: \n", regs->x13);
+    printf("Register[x14] value: 0x%lx: \n", regs->x14);
+    printf("Register[x15] value: 0x%lx: \n", regs->x15);
+    printf("Register[x16] value: 0x%lx: \n", regs->x16);
+    printf("Register[x17] value: 0x%lx: \n", regs->x17);
+    printf("Register[x18] value: 0x%lx: \n", regs->x18);
+    printf("Register[x19] value: 0x%lx: \n", regs->x19);
+    printf("Register[x20] value: 0x%lx: \n", regs->x20);
+    printf("Register[x21] value: 0x%lx: \n", regs->x21);
+    printf("Register[x22] value: 0x%lx: \n", regs->x22);
+    printf("Register[x23] value: 0x%lx: \n", regs->x23);
+    printf("Register[x24] value: 0x%lx: \n", regs->x24);
+    printf("Register[x25] value: 0x%lx: \n", regs->x25);
+    printf("Register[x26] value: 0x%lx: \n", regs->x26);
+    printf("Register[x27] value: 0x%lx: \n", regs->x27);
+    printf("Register[x28] value: 0x%lx: \n", regs->x28);
+    printf("Register[x29] value: 0x%lx: \n", regs->x29);
+    printf("Register[x30] value: 0x%lx: \n", regs->x30);
+
+    /* Now the stack pointer and the instruction pointer */
+    printf("Register[sp] value: 0x%lx: \n", regs->sp);
+    printf("Register[pc] value: 0x%lx: \n", regs->pc);
+
+    /* Finally the cpsr */
+    // return mem2hex((char *) &regs->spsr, buf, sizeof(seL4_Word) / 2);
+}
 
 /* Convert registers to a hex string */
 // @alwin: This is rather unpleasant, but the way the seL4_UserContext struct is formatted is annoying
@@ -114,7 +159,6 @@ char *hex2regs(seL4_UserContext *regs, char *buf)
 bool set_software_breakpoint(gdb_inferior_t *inferior, seL4_Word address) {
     sw_break_t tmp;
     tmp.addr = address;
-
     seL4_Word ret;
     uint32_t err = gdb_read_word(inferior->id, address, &ret);
     if (err) {
@@ -318,24 +362,20 @@ char *inf_mem2hex(gdb_thread_t *thread, seL4_Word mem, char *buf, int size, seL4
 {
     int i;
     unsigned char c;
+    char byte_buf[BUFSIZE];
 
-    seL4_Word curr_word = 0;
-    for (i = 0; i < size; i++) {
-        if (i % sizeof(seL4_Word) == 0) {
-            seL4_Word ret = 0;
-            uint32_t err = gdb_read_word(thread->inferior->id, mem, &ret);
-            if (err) {
-                *error = err;
-                return NULL;
-            }
+    uint32_t err = gdb_read_bytes(thread->inferior->id, mem, byte_buf, size);
+    if (err) {
+        *error = err;
+        return NULL;
+    }
 
-            curr_word = ret;
-            mem += sizeof(seL4_Word);
-        }
-
-        c = *(((char *) &curr_word) + (i % sizeof(seL4_Word)));
-        *buf++ = int_to_hexchar(c >> 4);
-        *buf++ = int_to_hexchar(c % 16);
+    for (int i = 0; i < size; i++) {
+        c = byte_buf[i];
+        *buf = int_to_hexchar(c >> 4);
+        buf++;
+        *buf = int_to_hexchar(c % 16);
+        buf++;
     }
 
     *buf = 0;
@@ -349,34 +389,17 @@ char *inf_mem2hex(gdb_thread_t *thread, seL4_Word mem, char *buf, int size, seL4
 seL4_Word inf_hex2mem(gdb_thread_t *thread, char *buf, seL4_Word mem, int size)
 {
     int i;
-    unsigned char c;
+    unsigned char write_buf[BUFSIZE];
 
-    seL4_Word curr_word = 0;
-    for (i = 0; i < size; i++, mem++) {
-        if (i % sizeof(seL4_Word) == 0) {
-
-            seL4_Word ret;
-            uint32_t err = gdb_read_word(thread->inferior->id, mem, &ret);
-            if (err) {
-                return (mem + i);
-            }
-
-            curr_word = ret;
-        }
-
-        c = hexchar_to_int(*buf++) << 4;
-        c += hexchar_to_int(*buf++);
-        *(((char *) &curr_word) + (i % sizeof(seL4_Word))) = c;
-
-        if (i % sizeof(seL4_Word) == sizeof(seL4_Word) - 1 || i == size - 1) {
-            int err = gdb_write_word(thread->inferior->id, mem + (i/sizeof(seL4_Word)), curr_word);
-            if (err) {
-                return (mem + i);
-            }
-
-            mem += sizeof(seL4_Word);
-        }
+    for (int i = 0; i < size; i++) {
+        write_buf[i] = hexchar_to_int(*buf++) << 4;
+        write_buf[i] += hexchar_to_int(*buf++);
     }
 
-    return (mem + i);
+    uint32_t bytes_written = gdb_write_bytes(thread->inferior->id, mem, write_buf, size);
+    if (bytes_written != size) {
+        printf("Could only write %u bytes of %u!\n", bytes_written, size);
+    }
+
+    return bytes_written;
 }

--- a/src/gdb.c
+++ b/src/gdb.c
@@ -259,10 +259,10 @@ DebuggerError gdb_register_inferior(uint64_t inferior_id, seL4_CPtr vspace) {
         inferior->gdb_id = ++curr_inferior_idx;
         inferior->vspace = vspace;
         inferior->curr_thread_idx = 0;
-        memset(inferior->threads, 0, MAX_THREADS * sizeof(gdb_thread_t));
-        memset(inferior->software_breakpoints, 0, MAX_SW_BREAKS * sizeof(sw_break_t));
-        memset(inferior->hardware_breakpoints, 0, seL4_NumExclusiveBreakpoints * sizeof(hw_break_t));
-        memset(inferior->hardware_watchpoints, 0, seL4_NumExclusiveWatchpoints * sizeof(hw_watch_t));
+        memset(&inferior->threads, 0, MAX_THREADS * sizeof(gdb_thread_t));
+        memset(&inferior->software_breakpoints, 0, MAX_SW_BREAKS * sizeof(sw_break_t));
+        memset(&inferior->hardware_breakpoints, 0, seL4_NumExclusiveBreakpoints * sizeof(hw_break_t));
+        memset(&inferior->hardware_watchpoints, 0, seL4_NumExclusiveWatchpoints * sizeof(hw_watch_t));
         return DebuggerError_NoError;
     }
 
@@ -611,9 +611,9 @@ static void handle_detach(char *ptr, char *output) {
                                       inferior->hardware_watchpoints[i].type,
                                       inferior->hardware_watchpoints[i].size);
         }
-        memset(inferior->software_breakpoints, 0, MAX_SW_BREAKS * sizeof(sw_break_t));
-        memset(inferior->hardware_breakpoints, 0, seL4_NumExclusiveBreakpoints * sizeof(hw_break_t));
-        memset(inferior->hardware_watchpoints, 0, seL4_NumExclusiveWatchpoints * sizeof(hw_watch_t));
+        memset(&inferior->software_breakpoints, 0, MAX_SW_BREAKS * sizeof(sw_break_t));
+        memset(&inferior->hardware_breakpoints, 0, seL4_NumExclusiveBreakpoints * sizeof(hw_break_t));
+        memset(&inferior->hardware_watchpoints, 0, seL4_NumExclusiveWatchpoints * sizeof(hw_watch_t));
 
         for (int j = 0; j < MAX_THREADS; j++) {
             if (!inferior->threads[j].enabled) continue;


### PR DESCRIPTION
Remove use of the deprecated read/write from vspace syscall and replace it with a direct read/write from the child's vspace. This is still a work in progress, pending seL4 PR and Microkit PR. The debugger (parent PD) walks the child's page tables that are mapped in via the Microkit tool, and maps the page it find in to a specific memory region that we create in the meta program. This currently only works with 4KiB pages.